### PR TITLE
Test behaviour adjustments

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+allow-unwrap-in-tests = true
+allow-indexing-slicing-in-tests = true


### PR DESCRIPTION
Added `clippy.toml` that allows using `unwrap()` and [index slicing](https://rust-lang.github.io/rust-clippy/master/index.html#indexing_slicing) in test context