### PR TITLE
apache2.0 with llvm exception

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -30,6 +30,7 @@ unmaintained = "workspace"
 allow = [
     "0BSD",
     "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
     "BSD-2-Clause-Patent",


### PR DESCRIPTION
- [Apache License 2.0 with LLVM Exception](https://llvm.org/LICENSE.txt) is approved now as well