### PR TITLE
Setting resolver to 3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 # TODO(template) update for the crate name
 [workspace]
 members = ["examples", "template_crate"]
-resolver = "2"
+resolver = "3"
 default-members = ["template_crate"]
 
 [workspace.package]


### PR DESCRIPTION
The new rust edition (2024) requires the resolver to be set to 3 rather than 2.