### PR TITLE
exclude gh workflows from cargo generate substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Signed commits
 
 ## How to use
 
-To generate a new project from this template, you need to install [cargo-generate](https://github.com/cargo-generate/cargo-generate) and run:
+Either with "Use this template" green button on Github or, in case of using another git hosting service (or have to avoid referencing this repository), you can use [cargo-generate](https://github.com/cargo-generate/cargo-generate).
 
 ```sh
 cargo install cargo-generate

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -7,8 +7,6 @@ cargo_generate_version = ">=0.23.0"
 
 # Exclude files from the placeholder generated for the template
 exclude = [
-    ".github/workflows/dependency-audit.yml",
-    ".github/workflows/coverage-pr.yml",
-    ".github/workflows/semver-checks.yml",
+    ".github/workflows",
     "target",
 ]


### PR DESCRIPTION
- [x] cannot generate a project with cargo generate because of the workflows `.github/workflows/coverage.yml` (better just to exclude them from vars expansion at all)