### PR TITLE
ci: Trigger dependency audit on deny.toml change

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
+      - 'deny.toml'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Audit should run if `deny.toml` is modified, to check the updated policy.