### PR TITLE
ci: remove external data JSON path from benchmark.yml

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -108,7 +108,6 @@ jobs:
           name: Rust Template Benchmark
           tool: "cargo"
           output-file-path: benchmark-output.txt
-          external-data-json-path: ./cache/benchmark-data.json
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: dev/bench
           alert-threshold: "130%"


### PR DESCRIPTION
Removed the external data JSON path from the benchmark configuration.