### PR TITLE
fix: repair the broken README badges

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,12 @@
 name: Docs
 
-# TODO(template)
-# GH pages seems to work properly for public repos
 on:
+  # Publishes rustdoc to GitHub Pages on every push to main.
+  # TODO(template) This REQUIRES GitHub Pages enabled (Settings -> Pages -> Source:
+  # GitHub Actions); until you enable it these runs will fail. If you publish the crate
+  # to crates.io instead, delete this workflow and use the docs.rs badge in the README.
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 # :crab: RUST PROJECT TEMPLATE - TODO(template) PUT PROJECT NAME HERE
 <!--`TODO(template) update each badge with your username and repository name.`-->
-[![Docs](https://github.com/NethermindEth/rust-template/actions/workflows/docs.yml/badge.svg)](https://github.com/NethermindEth/rust-template/actions/workflows/docs.yml)
 [![Lint](https://github.com/NethermindEth/rust-template/actions/workflows/linter.yml/badge.svg)](https://github.com/NethermindEth/rust-template/actions/workflows/linter.yml)
 [![Build](https://github.com/NethermindEth/rust-template/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/NethermindEth/rust-template/actions/workflows/build-and-test.yml)
 [![Dependencies](https://github.com/NethermindEth/rust-template/actions/workflows/dependency-audit.yml/badge.svg)](https://github.com/NethermindEth/rust-template/actions/workflows/dependency-audit.yml)
 [![UB](https://github.com/NethermindEth/rust-template/actions/workflows/ub-detection.yml/badge.svg)](https://github.com/NethermindEth/rust-template/actions/workflows/ub-detection.yml)
+[![Docs](https://github.com/NethermindEth/rust-template/actions/workflows/docs.yml/badge.svg)](https://github.com/NethermindEth/rust-template/actions/workflows/docs.yml)
+<!-- `TODO(template)` The Docs badge above tracks the GitHub Pages docs deploy (docs.yml) --
+     the default docs path for this template. It only turns GREEN once you enable GitHub
+     Pages (Settings -> Pages -> Source: GitHub Actions); until then docs.yml fails on push
+     and the badge is red. If instead you publish the crate to crates.io, docs.rs builds
+     your docs on publish -- delete docs.yml and swap the Docs badge above for this one:
+[![Docs](https://docs.rs/your-crate-name/badge.svg)](https://docs.rs/your-crate-name)
+-->
 <!-- You can replace them with a single badge if you create a main CI file that calls the other workflows
 [![CI](https://github.com/{{USERNAME}}/{{REPOSITORY}}/workflows/CI/badge.svg)](https://github.com/{{USERNAME}}/{{REPOSITORY}}/actions)
 -->
@@ -15,9 +22,9 @@ If you want to change from stable to Minimum Supported Rust Version (MSRV), repl
 ![Rust](https://img.shields.io/badge/rust-stable-orange.svg)
 <!--`TODO(template) update license version if needed. Check LICENSE first`-->
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-<!--`TODO(template) update with your crate information. Remove if not needed.`-->
-[![Crates.io](https://img.shields.io/crates/v/{{CRATE_NAME}}.svg)](https://crates.io/crates/{{CRATE_NAME}})
-[![Documentation](https://docs.rs/{{CRATE_NAME}}/badge.svg)](https://docs.rs/{{CRATE_NAME}})
+<!--`TODO(template)` set your-crate-name below; shows "crates.io | not found" until you
+    publish to crates.io. Remove this badge if you don't publish.-->
+[![Crates.io](https://img.shields.io/crates/v/your-crate-name.svg)](https://crates.io/crates/your-crate-name)
 
 TODO(template) describe the project
 
@@ -32,7 +39,7 @@ This is a rust template from ZKE team :rocket: (a focus on cryptographic libs in
 - [ ] Settings -> Pages -> Build and deployment -> Source Github Actions
 - [ ] Update the description of the repo at the repo's page, add tag topics
 - [ ] Introduce necessary sections at the repo's page (releases, deployments etc)
-- [ ] Add a website url (if applicable) or a docs page (see [docs](./.github/workflows/docs.yml) flow for public repos)
+- [ ] Docs: this template publishes rustdoc to GitHub Pages on push to main ([`docs.yml`](./.github/workflows/docs.yml)). Enable Pages (Settings -> Pages -> Source: GitHub Actions) so the deploy succeeds and the Docs badge turns green, and set the Pages URL as the repo website (About -> Website). If you publish to crates.io instead, delete `docs.yml` and use the docs.rs badge in the README
 - [ ] Add [all contributors](https://allcontributors.org/docs/en/cli/installation)
 - [ ] Import protection rulesets (see below) in the repo settings (Settings -> Rules -> Rulesets -> Import a ruleset)
 - [ ] For binary crates with specific requirements to Rust features consider also [pinning](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) the rust toolchain version

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Build](https://github.com/NethermindEth/rust-template/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/NethermindEth/rust-template/actions/workflows/build-and-test.yml)
 [![Dependencies](https://github.com/NethermindEth/rust-template/actions/workflows/dependency-audit.yml/badge.svg)](https://github.com/NethermindEth/rust-template/actions/workflows/dependency-audit.yml)
 [![UB](https://github.com/NethermindEth/rust-template/actions/workflows/ub-detection.yml/badge.svg)](https://github.com/NethermindEth/rust-template/actions/workflows/ub-detection.yml)
-[![Coverage](https://github.com/NethermindEth/rust-template/actions/workflows/coverage.yml/badge.svg)](https://github.com/NethermindEth/rust-template/actions/workflows/coverage.yml)
 <!-- You can replace them with a single badge if you create a main CI file that calls the other workflows
 [![CI](https://github.com/{{USERNAME}}/{{REPOSITORY}}/workflows/CI/badge.svg)](https://github.com/{{USERNAME}}/{{REPOSITORY}}/actions)
 -->


### PR DESCRIPTION
This PR resolves the broken or misleading badges in the template README.

**Coverage (dropped):**
The badge pointed at `coverage.yml`, a workflow that did not exist (the real one was `coverage-pr.yml`), so it rendered as a broken image. Pointing it at the correct `coverage-pr.yml` would have rendered correctly, however it would have been misleading, as it would only indicate whether the CI run succeeded (already shown by the CI flag) and not the coverage percentage (or whether it had regressed, given how the CI is structured). After considering how to show the percentage, either through persisting it in the Pages deploy or on a dedicated badges branch, both seemed awkward enough not to enforce as a default, and hence the removal of the badge.

**Docs:**
Docs in the repo can be published two ways (GitHub Pages via `docs.yml`, or docs.rs on a crates.io publish). Offering both badges caused issues, as they are effectively mutually exclusive: there should be only one canonical place for the docs, not two competing links. Pages is the default doc mode the template configures (with `docs.yml` running on push to main); if you publish to crates.io instead, delete `docs.yml` and swap in the docs.rs badge, kept as a commented snippet beside it.
